### PR TITLE
fixed👾

### DIFF
--- a/twitter_hoge.py
+++ b/twitter_hoge.py
@@ -8,40 +8,56 @@ from datetime import datetime
 twitter = Twython(APP_KEY, APP_SECRET, OAUTH_TOKEN, OAUTH_TOKEN_SECRET)
 print("Authentication Succeeded...")
 
+user_timeline = []
 # Function used to get tweet data
 def get_tweet (**params):
-	print("get_tweet()")
-	global user_timeline
-	try:
-		# Get user_timeline
-		user_timeline = twitter.get_user_timeline(screen_name = screen_name, include_rts = include_rts, count = count, since_id = since_id, max_id = since_id)
-		print("User Timeline Acquired...")
-	except TwythonError as e:
-		print(e)
-		
+    print("get_tweet()")
+    global user_timeline
+    try:
+        # Get user_timeline
+        user_timeline = twitter.get_user_timeline(**params)
+        print("User Timeline Acquired...")
+    except TwythonError as e:
+        print(e)
+
 # Function used to print tweet data
 def print_tweet (tweet):
-	print("print_tweet()")
-	if tweet != None:
-		for i in tweet:
-			print("ID : " + str(i['id']) + "\t" + "Remaining API : " + str(api))
-	else : 
-		print("No tweets!")
-		
+    print("print_tweet()")
+    if tweet != None:
+        for i in tweet:
+            print("ID : " + str(i['id']) + "\t" + "Remaining API : " + str(api))
+    else : 
+        print("No tweets!")
+
 # Get tweet data and remaining API 
-get_tweet()
+get_tweet(
+        screen_name = 'jeanmichel_bot',
+        include_rts = True,
+        count = 2,
+        #since_id = 0,
+        #max_id = 0
+)
 print("get_tweet()")
 api = int(twitter.get_lastfunction_header('X-Rate-limit-remaining'))
-
 # Get tweet data while remaining API > 0 
+max_id = user_timeline[-1]['id'] - 1
 while  api > 0:
-	print_tweet(user_timeline)
-	get_tweet()
-	api = api - 1
+    print_tweet(user_timeline)
+    get_tweet(
+            screen_name = 'jeanmichel_bot',
+            include_rts = True,
+            count = 2,
+            #since_id = 0,
+            max_id = max_id
+    )
+    max_id = user_timeline[-1]['id'] - 1
+    api = api - 1
 
-if api == 0 :
-	start = time.time()
-	end = float(twitter.get_lastfunction_header('X-Rate-limit-Reset'))
-	rem = (end - start)/1000
-	print("Remaining API : " + str(api) )
-	print("Please wait " + str(rem) + "sec")
+    if api == 0 :
+        start = time.time()
+        end = int(twitter.get_lastfunction_header('X-Rate-limit-Reset'))
+        rem = end - start + 5
+        print("Remaining API : " + str(api) )
+        print("Please wait " + str(rem) + "sec")
+        time.sleep(rem)
+


### PR DESCRIPTION
インデントをタブからスペースに変更

global user_timelineが初期化されてない
get_tweet()のtwitter.get_user_timelineの引数が変、それにともなって呼び出し方変更

やっぱりwhileループの下のif文のインデントがひとつ浅くてループ内ではなかった


取得したツイートの一番最後のtweet_id+1をmax_idに保存して次の取得はそれ以前のツイートを取得するように変更

APIのlimit来たらunixtime取得して待つ時間算出する処理が何故か1000で割ってたが、unixtimeはミリ秒ではない
pythonのtime.time()はunixtimeがfloatで来るからintに変換して引き算
ついでにその秒数sleepする処理を追加しといた